### PR TITLE
Add Voidly MCP — censorship intelligence for cybersecurity agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - [PortSwigger/mcp-server](https://github.com/PortSwigger/mcp-server) - MCP integration for Burp Suite, enabling web security testing and automation via agentic AI workflows.
 - [san-techie21/astracipher](https://github.com/san-techie21/astracipher) - Cryptographic identity MCP server for AI agents using W3C DIDs, Verifiable Credentials, and NIST post-quantum cryptography (ML-DSA-65 FIPS 204). Provides capability-bounded tool authorization, trust chain verification, and hybrid PQC signatures.
 - [urldna/mcp](https://github.com/urldna/mcp) - urlDNA MCP server for phishing detection and URL analysis through advanced contextual scanning.
+- [voidly-ai/mcp-server](https://www.npmjs.com/package/@voidly/mcp-server) - Global internet censorship intelligence MCP server with 116 tools across 119+ countries. OONI / IODA / CensoredPlanet evidence, 5,356 citable incidents, ISP-level risk scoring, ML-driven shutdown forecasting (Sentinel), and domain accessibility checks for nation-state network interference. Free read endpoints, no API key.
 
 ## Research
 - [AI CTF: Autonomous Agents in Cybersecurity Competitions](https://arxiv.org/abs/2311.09999) - Research on the use of agentic AI in CTF competitions and cybersecurity challenges.


### PR DESCRIPTION
Adds [`voidly-ai/mcp-server`](https://www.npmjs.com/package/@voidly/mcp-server) under **MCP Servers**.

Voidly fits this list because nation-state network interference (DNS poisoning, BGP-level outages, blockpages, TLS resets) is a real-world threat surface that cybersecurity agents need visibility into — and Voidly is the open data layer for it. 116 tools surface OONI / IODA / CensoredPlanet evidence across 119+ countries, 5,356 citable incidents (`IR-2026-0142` style), ISP-level risk scoring, ML-driven shutdown forecasting (Sentinel — AUC 0.98), and domain accessibility checks. Free read endpoints, no API key required.

Entry placed alphabetically (`v` after `urldna`) per the section's username-sorted format. CI alphabetical-ordering check should pass.

maintainer: @EmperorMew