### PR TITLE
Add tool-output-mimicry to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [pentagi](https://github.com/vxcontrol/pentagi) - Fully autonomous AI-powered agent system designed for penetration testing.
 - [Reaper](https://github.com/ghostsecurity/reaper) - Open Source Agentic Web App security testing and tampering tool by Ghost Security
 - [ShellWard](https://github.com/jnMetaCode/shellward) - AI agent security middleware with 8-layer defense-in-depth — prompt injection detection (32 rules), DLP-style data flow tracking (read PII → outbound send = blocked), dangerous command blocking, PII/API key scanning. Works as SDK or OpenClaw plugin. Zero dependencies.
+- [tool-output-mimicry](https://github.com/314-ia/tool-output-mimicry) - Reference reproducer for the Tool Output Mimicry primitive — bypasses multi-layer agentic AI defenses by impersonating an upstream agent's task summary in a user-controlled field that a downstream agent reads. Validated end-to-end against the OWASP FinBot CTF; companion paper at doi.org/10.5281/zenodo.19794072.
 - [Vulert](vulert.com) - Vulert secures software by detecting vulnerabilities in open-source dependencies—without accessing your code. It supports Js, PHP, Java, Python, and more
 
 ## Frameworks


### PR DESCRIPTION
## Summary

Adds [`314-ia/tool-output-mimicry`](https://github.com/314-ia/tool-output-mimicry) under **Tools**, alphabetically between `ShellWard` and `Vulert`.

## What it is

Reference reproducer for the *Tool Output Mimicry* primitive — a multi-agent attack that bypasses layered defenses by impersonating an upstream agent's task summary in a user-controllable field that a downstream agent reads. Companion paper:

> Brana, J. P. (2026). *Tool Output Mimicry: Bypassing Multi-Layer Agentic AI Defenses via Upstream-Agent Impersonation in User-Controlled Fields.* Zenodo. [doi:10.5281/zenodo.19794072](https://doi.org/10.5281/zenodo.19794072) (CC BY 4.0).

## Why this list

The threat model is explicitly multi-agent (orchestrator → upstream agent → downstream agent), which sits squarely in this list's scope. The repo ships:

- A reference Python implementation of the primitive (`UpstreamAgentImpersonation`, `generate_stego_html`)
- An end-to-end FinBot CTF reproducer with a `--dry-run` smoke test (zero credentials, CI-runnable)
- 24 unit tests passing on Python 3.10 / 3.11 / 3.12 / 3.13 (CI matrix green)
- Verbatim live-capture transcript from a freshly-registered CTF account (re-validated 2026-04-27)

## Conventions checked

- ✅ One line, `[Name](link) - description.` format per CONTRIBUTING.md
- ✅ Inserted in alphabetical order (case-insensitive) within Tools — between `ShellWard` (S) and `Vulert` (V)
- ✅ One suggestion per PR
- ✅ Description short enough to scan but specific enough to disambiguate from generic agent scanners