### PR TITLE
Add agentic-anti-patterns to Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [urldna/mcp](https://github.com/urldna/mcp) - urlDNA MCP server for phishing detection and URL analysis through advanced contextual scanning.
 
 ## Research
+- [agentic-anti-patterns](https://github.com/jimliu741523/agentic-anti-patterns) - Curated catalog of 20 documented LLM-agent failure modes (prompt injection via tool output, MCP server trust boundary collapse, RAG retrieval poisoning, exfiltration via agent-initiated fetch, autonomy creep, multi-agent vertical-domain failure, and more) with symptoms, root causes, mitigations, and detection methods per entry.
 - [AI CTF: Autonomous Agents in Cybersecurity Competitions](https://arxiv.org/abs/2311.09999) - Research on the use of agentic AI in CTF competitions and cybersecurity challenges.
 - [AutoCTF: Automated Capture The Flag Framework](https://arxiv.org/abs/2306.00988) - Research on an automated CTF framework using agentic AI for autonomous penetration testing and vulnerability discovery.
 - [BreachSeek](https://arxiv.org/html/2409.03789v1) - A Multi-Agent Automated Penetration Tester


### PR DESCRIPTION
Adds [agentic-anti-patterns](https://github.com/jimliu741523/agentic-anti-patterns) — a curated catalog of 20 documented LLM-agent failure modes — to the Research section.

Format: 1-line entry, alphabetical placement (before "AI CTF"). Per CONTRIBUTING.md.

MIT-licensed, no commercial backend.