### PR TITLE
Add APort to agentic cybersecurity tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 - [agenticsorg/agentic-security](https://github.com/agenticsorg/agentic-security) - An AI-powered security analysis tool intended to automatically detect vulnerabilities within code repositories.
 - [Aguara](https://github.com/garagon/aguara) - Static security scanner for AI agent skills and MCP servers. 173 detection rules, 4 analysis layers (pattern matching, NLP, taint tracking, rug-pull detection), offline, deterministic.
 - [AICA Agent](https://github.com/aica-iwg/aica-agent) - Autonomous intelligent cyberdefense agent for research and production, supporting advanced detection, response, and management capabilities.
+- [APort](https://aport.io) - Agent identity verification and policy enforcement for AI agents, with SDKs and middleware for applying runtime governance controls.
 - [brood-box](https://github.com/stacklok/brood-box) - CLI tool for running AI coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization profiles.
 - [`CAI` (Cybersecurity AI)](https://github.com/aliasrobotics/CAI) - Open-source Bug Bounty-ready AI system with hierarchical agentic patterns, supporting autonomous penetration testing, vulnerability discovery, and multi-agent cybersecurity workflows.
 - [ClawSearch](https://clawsearch.com/) - Search engine for AI agent skills with security-first indexing, surfacing audit results, risk scores, and safe alternatives for MCP servers and agent tools.


### PR DESCRIPTION
## Entry Details
- **Name of Project/Resource:** APort
- **Section (e.g., MCP Servers, Tools, Research, etc):** Tools
- **Link:** https://aport.io
- **Short Description:** Agent identity verification and policy enforcement for AI agents, with SDKs and middleware for applying runtime governance controls.

## Why is this awesome?
APort fits this list's agentic cybersecurity focus because it addresses runtime governance for AI agents: verifying agent identity, enforcing policy, and integrating through SDKs/middleware.

## Checklist
- [x] The entry is not a duplicate
- [x] The entry follows the format: `[Name](link) - Short description.`
- [x] The entry is placed in the correct section
- [x] The link is publicly accessible
- [x] The description is concise and clear
- [x] I have read the [contributing guidelines](CONTRIBUTING.md)

## Additional Notes
Related bounty: https://github.com/aporthq/aport-integrations/issues/19

Verification:
- `git diff --check -- README.md`
- `rg -n "APort|aport.io" README.md`
- `curl.exe -I -L --max-time 20 https://aport.io`

Payout if selected for the bounty: PayPal https://paypal.me/Jeremytsangchina or USDT TRC20 TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y