### PR TITLE
Add AI Agent Launch Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows.
 - [agenticsorg/agentic-security](https://github.com/agenticsorg/agentic-security) - An AI-powered security analysis tool intended to automatically detect vulnerabilities within code repositories.
 - [Aguara](https://github.com/garagon/aguara) - Static security scanner for AI agent skills and MCP servers. 173 detection rules, 4 analysis layers (pattern matching, NLP, taint tracking, rug-pull detection), offline, deterministic.
+- [AI Agent Launch Tools](https://github.com/kayalopez/ai-agent-launch-tools) - CLI and no-login checklists for scanning public AI-agent/MCP launch pages, approval gates, prompt-injection fixtures, and safe intake paths.
 - [AICA Agent](https://github.com/aica-iwg/aica-agent) - Autonomous intelligent cyberdefense agent for research and production, supporting advanced detection, response, and management capabilities.
 - [brood-box](https://github.com/stacklok/brood-box) - CLI tool for running AI coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization profiles.
 - [`CAI` (Cybersecurity AI)](https://github.com/aliasrobotics/CAI) - Open-source Bug Bounty-ready AI system with hierarchical agentic patterns, supporting autonomous penetration testing, vulnerability discovery, and multi-agent cybersecurity workflows.


### PR DESCRIPTION
Adds AI Agent Launch Tools to the Tools section.\n\nThe repo provides a CLI plus no-login checklists for scanning public AI-agent/MCP launch pages, approval gates, prompt-injection fixtures, and safe intake paths.\n\nValidation run locally:\n- bash scripts/check-alphabetical-order.sh\n- git diff --check\n\nNo paid checkout or private data is included in this awesome-list entry.