### PR TITLE
Add Xquik MCP server listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [san-techie21/astracipher](https://github.com/san-techie21/astracipher) - Cryptographic identity MCP server for AI agents using W3C DIDs, Verifiable Credentials, and NIST post-quantum cryptography (ML-DSA-65 FIPS 204). Provides capability-bounded tool authorization, trust chain verification, and hybrid PQC signatures.
 - [urldna/mcp](https://github.com/urldna/mcp) - urlDNA MCP server for phishing detection and URL analysis through advanced contextual scanning.
 - [voidly-ai/mcp-server](https://www.npmjs.com/package/@voidly/mcp-server) - Global internet censorship intelligence MCP server with 116 tools across 119+ countries. OONI / IODA / CensoredPlanet evidence, 5,356 citable incidents, ISP-level risk scoring, ML-driven shutdown forecasting (Sentinel), and domain accessibility checks for nation-state network interference. Free read endpoints, no API key.
+- [Xquik MCP Server](https://github.com/Xquik-dev/x-twitter-scraper) - API-key authenticated remote MCP server for X OSINT workflows: tweet search, user lookup, follower export, media download, monitors, and webhooks.
 
 ## Research
 - [AI CTF: Autonomous Agents in Cybersecurity Competitions](https://arxiv.org/abs/2311.09999) - Research on the use of agentic AI in CTF competitions and cybersecurity challenges.


### PR DESCRIPTION
## Entry Details
- **Name of Project/Resource:** Xquik MCP Server
- **Section (e.g., MCP Servers, Tools, Research, etc):** MCP Servers
- **Link:** https://github.com/Xquik-dev/x-twitter-scraper
- **Short Description:** API-key authenticated remote MCP server for X OSINT workflows: tweet search, user lookup, follower export, media download, monitors, and webhooks.

## Why is this awesome?
Xquik gives cybersecurity agents a remote MCP interface for SOCMINT-style X data workflows without handling X login material in the agent.

## Checklist
- [x] The entry is not a duplicate
- [x] The entry follows the format: `[Name](link) - Short description.`
- [x] The entry is placed in the correct section
- [x] The link is publicly accessible
- [x] The description is concise and clear
- [x] I have read the [contributing guidelines](CONTRIBUTING.md)

## Additional Notes (optional)
Validation run:
- `bash scripts/check-alphabetical-order.sh`
- `git diff --check`
- Changed-line confidentiality and dash scan
- Link check for the Xquik repository