### PR TITLE
Add Aeon to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 - [Vulert](vulert.com) - Vulert secures software by detecting vulnerabilities in open-source dependencies—without accessing your code. It supports Js, PHP, Java, Python, and more
 
 ## Frameworks
+- [Aeon](https://github.com/aaronjmars/aeon) - Autonomous agent framework that runs unattended on GitHub Actions, featuring a dedicated Onchain Security skill pack (rug-scan, contract-audit, honeypot-check, approval-audit) plus a `vuln-scanner` skill that finds and responsibly discloses real vulnerabilities.
 - [Agno](https://github.com/agno-agi/agno) - Lightweight, high-performance library for building Agents.
 - [ATFAA/SHIELD](https://arxiv.org/abs/2504.19956) - Advanced threat and mitigation frameworks for securing generative/agentic AI agents, with a focus on unique agent vulnerabilities and enterprise security.
 - [CrewAI](https://github.com/crewAIInc/crewAI) - Open-source framework for orchestrating teams of AI agents, supporting collaborative and specialized agentic workflows in security contexts.


### PR DESCRIPTION
Adds [Aeon](https://github.com/aaronjmars/aeon) to the **Frameworks** section.

Aeon is an autonomous agent framework (534★, TypeScript) that runs unattended on GitHub Actions. Its security relevance:

- **Onchain Security pack** — 15 skills including `rug-scan`, `contract-audit`, `honeypot-check`, `approval-audit`, `wallet-risk`, and `fund-flow`.
- **`vuln-scanner`** — finds real vulnerabilities and discloses them responsibly.
- Plus security-adjacent skills like `vuln-tracker`, `security-digest`, `workflow-audit`, and `disclosure-tracker`.

This fits alongside the other general agent frameworks already listed (Agno, CrewAI, LangChain, AutoGen) that are included for their use in security contexts.

### Checklist
- [x] Placed in the most appropriate section (Frameworks)
- [x] Alphabetical order — `Aeon` sorts before `Agno`; `scripts/check-alphabetical-order.sh` passes locally
- [x] Format: `- [Name](link) - description.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)