### PR TITLE
Add Armorer Guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 - [agenticsorg/agentic-security](https://github.com/agenticsorg/agentic-security) - An AI-powered security analysis tool intended to automatically detect vulnerabilities within code repositories.
 - [Aguara](https://github.com/garagon/aguara) - Static security scanner for AI agent skills and MCP servers. 173 detection rules, 4 analysis layers (pattern matching, NLP, taint tracking, rug-pull detection), offline, deterministic.
 - [AICA Agent](https://github.com/aica-iwg/aica-agent) - Autonomous intelligent cyberdefense agent for research and production, supporting advanced detection, response, and management capabilities.
+- [Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard) - Local Rust security scanner and MCP proxy for AI agents that detects prompt injection, credential leakage, exfiltration, and risky tool-call arguments before execution.
 - [brood-box](https://github.com/stacklok/brood-box) - CLI tool for running AI coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization profiles.
 - [`CAI` (Cybersecurity AI)](https://github.com/aliasrobotics/CAI) - Open-source Bug Bounty-ready AI system with hierarchical agentic patterns, supporting autonomous penetration testing, vulnerability discovery, and multi-agent cybersecurity workflows.
 - [ClawSearch](https://clawsearch.com/) - Search engine for AI agent skills with security-first indexing, surfacing audit results, risk scores, and safe alternatives for MCP servers and agent tools.


### PR DESCRIPTION
Adds Armorer Guard to the Tools section.\n\nDisclosure: I maintain Armorer Guard at Armorer Labs. It is a MIT-licensed local Rust security scanner and MCP proxy for AI agents that detects prompt injection, credential leakage, exfiltration, and risky tool-call arguments before execution. I placed it in Tools because this list tracks practical agentic cybersecurity projects and Armorer Guard is meant to sit directly in the runtime path for agent apps and MCP-capable systems.\n\nThanks for maintaining this catalog.