### PR TITLE
Add Redcells to security testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 - [ShellWard](https://github.com/jnMetaCode/shellward) - AI agent security middleware with 8-layer defense-in-depth — prompt injection detection (32 rules), DLP-style data flow tracking (read PII → outbound send = blocked), dangerous command blocking, PII/API key scanning. Works as SDK or OpenClaw plugin. Zero dependencies.
 - [tool-output-mimicry](https://github.com/314-ia/tool-output-mimicry) - Reference reproducer for the Tool Output Mimicry primitive — bypasses multi-layer agentic AI defenses by impersonating an upstream agent's task summary in a user-controlled field that a downstream agent reads. Validated end-to-end against the OWASP FinBot CTF; companion paper at doi.org/10.5281/zenodo.19794072.
 - [Vulert](vulert.com) - Vulert secures software by detecting vulnerabilities in open-source dependencies—without accessing your code. It supports Js, PHP, Java, Python, and more
+- [Redcells](https://redcells.net) - automated adversarial testing platform for OpenAI-compatible LLMs you own or control. Run structured red-team jobs (prompt injection, jailbreak, data leakage) with an iterative attack→refine pipeline and per-layer scoring dashboard.
 
 ## Frameworks
 - [Aeon](https://github.com/aaronjmars/aeon) - Autonomous agent framework that runs unattended on GitHub Actions, featuring a dedicated Onchain Security skill pack (rug-scan, contract-audit, honeypot-check, approval-audit) plus a `vuln-scanner` skill that finds and responsibly discloses real vulnerabilities.


### PR DESCRIPTION
Adds [Redcells](https://redcells.net) — an automated adversarial testing platform for OpenAI-compatible LLMs you own or control. Run structured red-team jobs (prompt injection, jailbreak, data leakage) with an iterative attack→refine pipeline and per-layer scoring. Fits the existing Tools section alongside AgentFence, pentagi, Reaper, etc.