### PR TITLE
Update README.md: Add Trent AI to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 - [rolandpg/zettelforge](https://github.com/rolandpg/zettelforge) - CTI agentic memory MCP server with entity extraction (CVEs, threat actors, IOCs, MITRE ATT&CK), knowledge graph with alias resolution, STIX 2.1 ontology, and intent-classified retrieval. Offline, no API keys.
 - [ShellWard](https://github.com/jnMetaCode/shellward) - AI agent security middleware with 8-layer defense-in-depth — prompt injection detection (32 rules), DLP-style data flow tracking (read PII → outbound send = blocked), dangerous command blocking, PII/API key scanning. Works as SDK or OpenClaw plugin. Zero dependencies.
 - [tool-output-mimicry](https://github.com/314-ia/tool-output-mimicry) - Reference reproducer for the Tool Output Mimicry primitive — bypasses multi-layer agentic AI defenses by impersonating an upstream agent's task summary in a user-controlled field that a downstream agent reads. Validated end-to-end against the OWASP FinBot CTF; companion paper at doi.org/10.5281/zenodo.19794072.
+- [Trent AI - Agentic AI security platform](https://trent.ai) - Continuously assess AI agents, MCP servers, AI-native applications, and code shipped with AI coding tools; trace attack chains; and verify proposed fixes landed.
 - [Vulert](vulert.com) - Vulert secures software by detecting vulnerabilities in open-source dependencies—without accessing your code. It supports Js, PHP, Java, Python, and more
 
 ## Frameworks


### PR DESCRIPTION
Adds Trent AI to Tools, placed alphabetically per CONTRIBUTING.

Disclosure: I work on Trent

# Pull Request: Add New Item to Awesome Agentic AI in Cybersecurity

## Entry Details
- **Name of Project/Resource:** Trent AI Agentic AI security platform
- **Section (e.g., MCP Servers, Tools, Research, etc):** Tools
- **Link:** https://trent.ai
- **Short Description:** Agentic AI security platform that continuously assesses AI agents, MCP servers, and code shipped with AI coding tools, traces attack chains, and verifies proposed fixes landed.

## Why is this awesome?
Most security tooling scans static code, but agentic systems change behavior without a release: a new tool, an edited prompt, or a new MCP server rewires the attack surface. Trent treats the agent's runtime capabilities (read, write, execute, egress) as the unit of analysis, traces how agents, tools, and MCP servers could be chained into an attack, and re-assesses as the system changes. It also ships trentclaw, an open-source security assessment skill for the OpenClaw runtime (https://github.com/trnt-ai/trent-openclaw-security-assessment), which the community can use self-serve.

## Checklist
- [ x] The entry is not a duplicate
- [ x] The entry follows the format: `[Name](link) - Short description.`
- [ x] The entry is placed in the correct section
- [ x] The link is publicly accessible
- [ x] The description is concise and clear
- [ x] I have read the [contributing guidelines](CONTRIBUTING.md)

## Additional Notes (optional)
Add any extra context or relevant information here.

---
Thank you for helping make this list more awesome! 