### PR TITLE
Add Vigil (VigilSOC) to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 - [rolandpg/zettelforge](https://github.com/rolandpg/zettelforge) - CTI agentic memory MCP server with entity extraction (CVEs, threat actors, IOCs, MITRE ATT&CK), knowledge graph with alias resolution, STIX 2.1 ontology, and intent-classified retrieval. Offline, no API keys.
 - [ShellWard](https://github.com/jnMetaCode/shellward) - AI agent security middleware with 8-layer defense-in-depth — prompt injection detection (32 rules), DLP-style data flow tracking (read PII → outbound send = blocked), dangerous command blocking, PII/API key scanning. Works as SDK or OpenClaw plugin. Zero dependencies.
 - [tool-output-mimicry](https://github.com/314-ia/tool-output-mimicry) - Reference reproducer for the Tool Output Mimicry primitive — bypasses multi-layer agentic AI defenses by impersonating an upstream agent's task summary in a user-controlled field that a downstream agent reads. Validated end-to-end against the OWASP FinBot CTF; companion paper at doi.org/10.5281/zenodo.19794072.
+- [Vigil (VigilSOC)](https://github.com/Vigil-SOC/vigil) - Open-source agentic AI SOC (Apache 2.0) with 13 specialized security agents, MCP integrations, and 7,200+ detection rules across Sigma, Splunk, Elastic, and KQL. Multi-agent workflows defined as plain Markdown cover incident response, investigation, threat hunting, and forensic analysis.
 - [Vulert](vulert.com) - Vulert secures software by detecting vulnerabilities in open-source dependencies—without accessing your code. It supports Js, PHP, Java, Python, and more
 
 ## Frameworks


### PR DESCRIPTION
# Pull Request: Add New Item to Awesome Agentic AI in Cybersecurity

## Entry Details
- **Name of Project/Resource:** Vigil (VigilSOC)
- **Section (e.g., MCP Servers, Tools, Research, etc):** Tools
- **Link:** https://github.com/Vigil-SOC/vigil
- **Short Description:** Open-source agentic AI SOC (Apache 2.0) with 13 specialized security agents, 30+ MCP integrations, and 7,200+ detection rules across Sigma, Splunk, Elastic, and KQL. Multi-agent workflows defined as plain Markdown cover incident response, investigation, threat hunting, and forensic analysis.

## Why is this awesome?
Vigil is a fully open-source (Apache 2.0) agentic SOC, so teams can own and inspect the whole pipeline instead of renting a black box. It is agentic by design rather than a chat wrapper: 13 specialized agents (triage, investigation, threat hunting, malware analysis, forensics, compliance) execute real work against 30+ tools wired in over the Model Context Protocol — Splunk, CrowdStrike, VirusTotal, Jira, Slack and more. Multi-agent workflows are plain Markdown files, so playbooks are readable, reviewable, and extensible by anyone on the team, and the 7,200+ community detection rules across Sigma, Splunk, Elastic, and KQL come with coverage and gap analysis. That combination — MCP-native integrations, transparent agent orchestration, and a permissive license — makes it a useful reference implementation for the agentic-AI-in-security community, not just another product listing.

## Checklist
- [x] The entry is not a duplicate
- [x] The entry follows the format: `[Name](link) - Short description.`
- [x] The entry is placed in the correct section
- [x] The link is publicly accessible
- [x] The description is concise and clear
- [x] I have read the [contributing guidelines](CONTRIBUTING.md)

## Additional Notes (optional)
Placed alphabetically in the **Tools** section between `tool-output-mimicry` and `Vulert`, per the ordering rule in CONTRIBUTING.md. `scripts/check-alphabetical-order.sh` passes locally (all sections ok). One-line diff; no other changes.

Disclosure: I work at DeepTempo, the maintainer of Vigil.

---
Thank you for helping make this list more awesome!
