### PR TITLE
Add AI Cyber Alliance to Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@
 - [PromptTrace](https://prompttrace.airedlab.com) - Free hands-on AI security training platform. Practice prompt injection, RAG poisoning, and tool exploitation against real LLMs with full prompt stack visibility. Includes 10 labs, a 15-level CTF (The Gauntlet), and 9 learning modules aligned with OWASP Top 10 for LLMs.
 
 ## Communities
-- *Submit your awesome Agentic AI Cybersecurity community here!*
+- [AI Cyber Alliance](https://ai-cyber-alliance.org) - Practitioner-driven community at the intersection of AI and cybersecurity, running bi-weekly in-person meetups of short technical talks, Q&A, and networking for engineers, researchers, and maintainers — no vendor pitches. Currently meets in San Francisco, the Bay Area, Washington DC, Boston, and Austin, with more cities to be announced.
 
 ---
 


### PR DESCRIPTION
# Pull Request: Add New Item to Awesome Agentic AI in Cybersecurity

## Entry Details
- **Name of Project/Resource:** AI Cyber Alliance
- **Section (e.g., MCP Servers, Tools, Research, etc):** Communities
- **Link:** https://ai-cyber-alliance.org
- **Short Description:** Practitioner-driven community at the intersection of AI and cybersecurity, running bi-weekly in-person meetups of short technical talks, Q&A, and networking for engineers, researchers, and maintainers — no vendor pitches. Currently meets in San Francisco, the Bay Area, Washington DC, Boston, and Austin, with more cities to be announced.

## Why is this awesome?
The Communities section is currently empty, and this fills it with a genuinely practitioner-driven group rather than a vendor channel. AI Cyber Alliance is community-led and explicitly excludes sales pitches: each bi-weekly gathering is two short technical talks plus Q&A and networking, drawing 50–70 engineers, researchers, SREs, open source maintainers, and technical leaders working across AI, cybersecurity, and cloud-native. Crucially it is **in person** across multiple US metros — San Francisco, the Bay Area, Washington DC, Boston, and Austin, with more cities to be announced — which makes it a rare face-to-face complement to the tools, papers, and newsletters that make up the rest of this list. Past talks are archived publicly on YouTube and speaker submissions are open, so the knowledge is accessible even to people outside those cities.

## Checklist
- [x] The entry is not a duplicate
- [x] The entry follows the format: `[Name](link) - Short description.`
- [x] The entry is placed in the correct section
- [x] The link is publicly accessible
- [x] The description is concise and clear
- [x] I have read the [contributing guidelines](CONTRIBUTING.md)

## Additional Notes (optional)
This is the first entry in the **Communities** section, so the diff also removes the `- *Submit your awesome Agentic AI Cybersecurity community here!*` placeholder that the section carried while empty. Happy to restore that line if you would rather keep the call-to-action alongside real entries — just say so and I will push a follow-up.

Alphabetical ordering is trivially satisfied as the only entry; `scripts/check-alphabetical-order.sh` passes locally with `Communities: 1 entry (ok)` and all other sections unchanged.

---
Thank you for helping make this list more awesome!
