### PR TITLE
Add CyberAgents Exchange to Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@
 
 ## Communities
 - [AI Cyber Alliance](https://ai-cyber-alliance.org) - Practitioner-driven community at the intersection of AI and cybersecurity, running bi-weekly in-person meetups of short technical talks, Q&A, and networking for engineers, researchers, and maintainers — no vendor pitches. Currently meets in San Francisco, the Bay Area, Washington DC, Boston, and Austin, with more cities to be announced.
+- [CyberAgents Exchange](https://exchange.tenable.com) - Open-source, vendor-agnostic directory and community, powered by Tenable, where practitioners discover, share, and compose AI agents, skills, MCP servers, and playbooks for cybersecurity.
 
 ---
 


### PR DESCRIPTION
## Entry Details
- **Name of Project/Resource:** CyberAgents Exchange
- **Section:** Communities
- **Link:** https://exchange.tenable.com
- **Short Description:** Open-source, vendor-agnostic directory and community, powered by Tenable, where practitioners discover, share, and compose AI agents, skills, MCP servers, and playbooks for cybersecurity.

## Why is this awesome?
CyberAgents Exchange is a vendor-agnostic hub specifically for cybersecurity agentic AI — agents, skills, MCP servers, and playbooks — rather than a general-purpose agent marketplace. Every listing links directly to its source repo, there's an active Discord and GitHub org, and a public contributor leaderboard. It fits this list's mission of surfacing where the community builds and shares, and complements the existing MCP Servers/Tools/Frameworks sections by pointing readers to a live place to contribute their own work.

## Checklist
- [x] The entry is not a duplicate
- [x] The entry follows the format: `[Name](link) - Short description.`
- [x] The entry is placed in the correct section
- [x] The link is publicly accessible
- [x] The description is concise and clear
- [x] I have read the contributing guidelines