### PR TITLE
Add Open-ReverseLab: reverse-engineering MCP server with 100+ tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - [BurtTheCoder/mcp-virustotal](https://github.com/BurtTheCoder/mcp-virustotal) - MCP server for querying the VirusTotal API for file and URL malware analysis.
 - [ExposureGuard/exposureguard-mcp](https://github.com/ExposureGuard/exposureguard-mcp) - Domain security scanning for AI agents. 8-check audit (SPF, DMARC, SSL, headers, DNSSEC, ports), A-F grades, fix snippets. [getexposureguard.com](https://getexposureguard.com)
 - [ExposureGuard/haldir](https://github.com/ExposureGuard/haldir) - Guardian layer for AI agents: scoped sessions (Gate), encrypted secrets (Vault), audit trail (Watch), proxy mode for policy enforcement. Identity, spend limits, human-in-the-loop approvals. [haldir.xyz](https://haldir.xyz)
+- [LING71671/open-reverselab](https://github.com/LING71671/open-reverselab) - Open-source MCP server exposing 100+ reverse-engineering tools (Ghidra headless, Frida, x64dbg, Rizin, YARA, triage) to AI agents, backed by a runnable CTF/APK/PE attack knowledge base.
 - [MCPPhalanx/binaryninja-mcp](https://github.com/MCPPhalanx/binaryninja-mcp) - MCP server for Binary Ninja, enabling binary analysis and reverse engineering in agentic workflows.
 - [mobilehackinglab/jadx-mcp-plugin](https://github.com/mobilehackinglab/jadx-mcp-plugin) - Jadx plugin for MCP server access, used for decompiling Android apps.
 - [MorDavid/BloodHound-MCP-AI](https://github.com/MorDavid/BloodHound-MCP-AI) - MCP server for BloodHound, providing Active Directory analysis and attack path discovery for agentic AI.


### PR DESCRIPTION
## Entry Details
- **Name of Project/Resource:** [LING71671/open-reverselab](https://github.com/LING71671/open-reverselab)
- **Section:** MCP Servers
- **Link:** https://github.com/LING71671/open-reverselab
- **Short Description:** Open-source MCP server exposing 100+ reverse-engineering tools (Ghidra headless, Frida, x64dbg, Rizin, YARA, triage) to AI agents, backed by a runnable CTF/APK/PE attack knowledge base.

## Why is this awesome?
Open-ReverseLab's `reverse_lab_tools` is one of the few *multi-tool* RE MCP servers: alongside ghidra_mcp / x64dbg_mcp / jadx-mcp-plugin already listed, it bundles Ghidra headless, Frida, x64dbg, Rizin and YARA in a single server plus a 190+ article attack knowledge base (CTF/APK/PE), so agents get both tooling and methodology.

## Checklist
- [x] The entry is not a duplicate
- [x] The entry follows the format: `[Name](link) - Short description.`
- [x] The entry is placed in the correct section
- [x] The link is publicly accessible
- [x] The description is concise and clear
- [x] I have read the contributing guidelines